### PR TITLE
Add interpolation logic for third-person camera pivot

### DIFF
--- a/Content/Camera/CM_ThirdPerson.uasset
+++ b/Content/Camera/CM_ThirdPerson.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2c405305cd245d578a4959b0c111e437132a594de37cb4dc82da518bcd653a79
-size 5925
+oid sha256:63083be11787a7f9ca3147f9945fe87a96b09eaae1f24a818c0505cf41bce998
+size 5979

--- a/Source/SF/Camera/SFCameraMode_ThirdPerson.h
+++ b/Source/SF/Camera/SFCameraMode_ThirdPerson.h
@@ -24,6 +24,9 @@ public:
 	USFCameraMode_ThirdPerson();
 
 protected:
+	// 이 카메라 모드가 활성화될 때 한 번 호출됩니다.
+	virtual void OnActivation() override;
+	
 	// 매 프레임 뷰(시점) 업데이트 (3인칭 로직 적용).
 	virtual void UpdateView(float DeltaTime) override;
 
@@ -57,6 +60,18 @@ protected:
 	UPROPERTY(EditDefaultsOnly, Category = "Third Person", Meta = (EditCondition = "bUseRuntimeFloatCurves"))
 	FRuntimeFloatCurve TargetOffsetZ;
 
+	/**
+	 * 카메라 피벗이 캐릭터를 따라가는 속도
+	 * [낮을수록] (예: 5.0) 카메라는 더 느리고 '느슨하게' 따라옴.
+	 * [높을수록] (예: 20.0) 카메라는 더 빠릿하고 '즉각적으로' 반응.
+	 */
+	UPROPERTY(EditDefaultsOnly, Category = "Third Person|Lag")
+	float PivotFollowSpeed = 10.0f;
+
+	 // 실제 카메라 계산에 사용될 '보간된' 피벗 위치
+	UPROPERTY(Transient)
+	FVector SmoothedPivotLocation;
+	
 	// 앉기 상태일 때 카메라 오프셋(위치 보정) 블렌드 속도.
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Third Person")
 	float CrouchOffsetBlendMultiplier = 5.0f;


### PR DESCRIPTION
### 설명 (Description)

이번 작업은 3인칭 카메라 피벗에 **보간(Interpolation) 로직**을 도입하여, 한층 더 부드러운 카메라 움직임을 구현하는 것을 목표로 합니다. 핵심 변경 사항은 다음과 같습니다:

* **`OnActivation` 메서드 오버라이드**: 카메라가 활성화되는 순간, 피벗 위치를 캐릭터의 현재 위치로 즉시 설정하여 '툭' 튀는 현상을 방지합니다.
* **`UpdateView` 메서드 업데이트**: 카메라 뷰가 업데이트될 때, '이상적인(Ideal)' 피벗 위치에서 '보간된(Interpolated)' 피벗 위치로 부드럽게 **블렌딩(Blending)** 하도록 로직을 수정합니다.
* **`PivotFollowSpeed` 변수 도입**: 이 값을 조절하여 카메라가 피벗을 얼마나 '빠르게' 또는 '느리게' 따라올지, 즉 **보간 속도**를 제어할 수 있게 되었습니다.
* **계산 로직 변경**: 실제 최종 피벗 위치를 계산할 때, 딱딱한 목표 위치 대신 **보간된 피벗 위치**를 사용하도록 수정합니다.
* **신규 데이터 멤버 추가**: `SmoothedPivotLocation` (부드럽게 처리된 피벗 위치) 등 보간 과정을 관리하기 위한 새로운 변수들을 추가합니다.

---

### 점검 목록 (Checklist)

* [x] 코드에 주석이 잘 작성되었는가?
* [x] 필요한 경우 유닛 테스트가 추가/업데이트되었는가?
* [x] 영향받는 기능에 대해 수동 테스트를 수행했는가?
* [x] 코드가 프로젝트의 스타일 가이드라인을 준수하는가?