### PR TITLE
데미지 및 체력 처리 로직 추가

### DIFF
--- a/Source/SF/AbilitySystem/Attributes/SFPrimarySet.cpp
+++ b/Source/SF/AbilitySystem/Attributes/SFPrimarySet.cpp
@@ -6,6 +6,9 @@
 #include "AbilitySystem/SFAbilitySystemComponent.h"
 #include "Net/UnrealNetwork.h"
 
+#include "GameplayEffectExtension.h"
+#include "Character/SFCharacterGameplayTags.h"
+
 USFPrimarySet::USFPrimarySet()
 {
 }
@@ -22,13 +25,48 @@ void USFPrimarySet::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLif
 bool USFPrimarySet::PreGameplayEffectExecute(FGameplayEffectModCallbackData& Data)
 {
 	return Super::PreGameplayEffectExecute(Data);
-	
 }
 
 void USFPrimarySet::PostGameplayEffectExecute(const FGameplayEffectModCallbackData& Data)
 {
 	Super::PostGameplayEffectExecute(Data);
-	
+
+	// 변경된 Attribute가 'Damage'인지 확인
+	if (Data.EvaluatedData.Attribute == GetDamageAttribute())
+	{
+		// 1. 데미지 값(DamageDone)을 로컬 변수에 저장
+		const float DamageDone = GetDamage();
+		// 2. 임시 Attribute인 Damage를 다시 0으로 초기화
+		SetDamage(0.0f);
+
+		// 3.체력이 0보다 크고 유효한 데미지가 들어왔는지 확인
+		if (DamageDone > 0.0f && GetHealth() > 0.0f)
+		{
+			// 4. 'Damage'를 'Health'에 적용
+			SetHealth(GetHealth() - DamageDone);
+		}
+	}
+
+	// 변경된 Attribute가 'Health'인지 확인
+	if (Data.EvaluatedData.Attribute == GetHealthAttribute())
+	{
+		// 5. 체력이 0 이하가 되었는지 확인 (사망)
+		if (GetHealth() <= 0.0f)
+		{
+			if (USFAbilitySystemComponent* SFASC = GetSFAbilitySystemComponent())
+			{
+				// 6. 사망 태그가 없는 경우에만 부여 (중복방지)
+				if (!SFASC->HasMatchingGameplayTag(SFGameplayTags::Character_State_Dead))
+				{
+					SFASC->AddLooseGameplayTag(SFGameplayTags::Character_State_Dead);
+
+					// TODO: 후에 GA_Death와 같은 사망 전용 어빌리티 활성화
+					// FGamplayEventData Payload;
+					// SFASC->HandleGameplayEvent(SFGameplayTags::Event_Death, &Payload);
+				}
+			}
+		}
+	}
 }
 
 void USFPrimarySet::PreAttributeBaseChange(const FGameplayAttribute& Attribute, float& NewValue) const

--- a/Source/SF/AbilitySystem/Attributes/SFPrimarySet.h
+++ b/Source/SF/AbilitySystem/Attributes/SFPrimarySet.h
@@ -23,7 +23,7 @@ public:
 protected:
 	virtual bool PreGameplayEffectExecute(FGameplayEffectModCallbackData& Data) override;
 	virtual void PostGameplayEffectExecute(const FGameplayEffectModCallbackData& Data) override;
-
+	
 	virtual void PreAttributeBaseChange(const FGameplayAttribute& Attribute, float& NewValue) const override;
 	virtual void PreAttributeChange(const FGameplayAttribute& Attribute, float& NewValue) override;
 	virtual void PostAttributeChange(const FGameplayAttribute& Attribute, float OldValue, float NewValue) override;
@@ -34,6 +34,7 @@ public:
 	ATTRIBUTE_ACCESSORS(ThisClass, Health);
 	ATTRIBUTE_ACCESSORS(ThisClass, MaxHealth);
 	ATTRIBUTE_ACCESSORS(ThisClass, MoveSpeed);
+	ATTRIBUTE_ACCESSORS(ThisClass, Damage);
 
 protected:
 	UFUNCTION()
@@ -54,4 +55,7 @@ private:
 
 	UPROPERTY(BlueprintReadOnly, ReplicatedUsing=OnRep_MoveSpeed, meta=(AllowPrivateAccess="true"))
 	FGameplayAttributeData MoveSpeed;
+
+	UPROPERTY(BlueprintReadOnly, meta=(AllowPrivateAccess="true"))
+	FGameplayAttributeData Damage;
 };


### PR DESCRIPTION
### 설명

이 PR은 `Damage` 및 `Health` 어트리뷰트(속성)를 처리하는 로직을 도입하여, 캐릭터의 데미지 처리 및 사망 상태로의 전환을 구현합니다. 주요 업데이트 내용은 다음과 같습니다:

- `Damage` 어트리뷰트와 관련 데이터 멤버 및 접근자 매크로 추가.
- `PostGameplayEffectExecute` 메서드 내에 `Damage`를 `Health`에 반영하는 로직 통합.
- `Health`가 0 이하로 떨어질 경우, `Character_State_Dead` 게임플레이 태그를 자동으로 할당하여 캐릭터를 사망 상태로 표시.
- 클래스 정의 및 `include` 구문 등 관련 헤더 파일과 소스 파일 업데이트.

### 체크리스트

- [x] (해당하는 경우) 유닛 테스트 추가 또는 업데이트
- [x] (해당하는 경우) 문서 업데이트
- [x] 변경 사항의 정확성 검증 완료