### PR TITLE
Feat: 메인메뉴 WBP 관련 로직 구현

### DIFF
--- a/Config/DefaultEngine.ini
+++ b/Config/DefaultEngine.ini
@@ -1,10 +1,10 @@
 
 
 [/Script/EngineSettings.GameMapsSettings]
-GameDefaultMap=/Game/Maps/L_TestMainMenu_HJY.L_TestMainMenu_HJY
+GameDefaultMap=/Game/Maps/L_MainMenu.L_MainMenu
 GameInstanceClass=/Game/System/BP_SFGameInstance.BP_SFGameInstance_C
 TransitionMap=/Game/Maps/L_Transition_Empty.L_Transition_Empty
-EditorStartupMap=/Engine/Maps/Templates/OpenWorld.OpenWorld
+EditorStartupMap=/Game/Maps/L_MainMenu.L_MainMenu
 
 [/Script/Engine.RendererSettings]
 r.AllowStaticLighting=False

--- a/Content/UI/MainMenu/WBP_MainMenu_LJG.uasset
+++ b/Content/UI/MainMenu/WBP_MainMenu_LJG.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c2664ce7e971933ba39ae457560af165e731eff403778f6dc9e56f13d073bd53
-size 44534
+oid sha256:b693218fc977816e21880242d8fb92adf0e1afe03d4b0575c1feb1daaba74a52
+size 44407

--- a/Source/SF/UI/MainMenu/MainMenuWidget.cpp
+++ b/Source/SF/UI/MainMenu/MainMenuWidget.cpp
@@ -1,0 +1,95 @@
+#include "UI/MainMenu/MainMenuWidget.h"
+
+#include "Kismet/GameplayStatics.h"
+#include "Kismet/KismetSystemLibrary.h"
+
+void UMainMenuWidget::NativeConstruct()
+{
+	Super::NativeConstruct();
+
+	if (IsValid(Btn_NewGame))
+	{
+		Btn_NewGame->OnButtonClickedDelegate.AddDynamic(this, &UMainMenuWidget::OnNewGameClicked);
+	}
+
+	if (IsValid(Btn_SearchMatch))
+	{
+		Btn_SearchMatch->OnButtonClickedDelegate.AddDynamic(this, &UMainMenuWidget::OnSearchMatchClicked);
+	}
+
+	if (IsValid(Btn_Options))
+	{
+		Btn_Options->OnButtonClickedDelegate.AddDynamic(this, &UMainMenuWidget::OnOptionsClicked);
+	}
+
+	if (IsValid(Btn_Credits))
+	{
+		Btn_Credits->OnButtonClickedDelegate.AddDynamic(this, &UMainMenuWidget::OnCreditsClicked);
+	}
+	
+	if (IsValid(Btn_Quit))
+	{
+		Btn_Quit->OnButtonClickedDelegate.AddDynamic(this, &UMainMenuWidget::OnQuitClicked);
+	}
+}
+
+void UMainMenuWidget::OnNewGameClicked()
+{
+	/*if (!LobbyMapAsset.IsValid())
+	{
+		UE_LOG(LogTemp, Error, TEXT("LobbyMapAsset 이 UMainMenuWidget BP에서 설정되지 않았습니다."));
+		return;
+	}*/
+
+	// 1. 맵 이름 가져오기
+	FString MapName = LobbyMapAsset.GetLongPackageName();
+
+	// 2. 멀티플레이 세션 생성을 위한 옵션 정의
+	// -> 해당 맵을 listen 서버로 열기 위하여 ?listen 옵션 추가 -> 다른 클라이언트 접속을 위한 호스트 지정
+	FString TravelURL = FString::Printf(TEXT("%s?listen"), *MapName);
+
+	// 3. 서버 맵 이동 (월드 트레블)
+	if (UWorld* World = GetWorld())
+	{
+		APlayerController* PC = UGameplayStatics::GetPlayerController(World, 0 );
+
+		if (PC && TravelURL != "")
+		{
+			// PC 서버(월드) 이동 요청 
+			PC->ClientTravel(TravelURL, TRAVEL_Absolute);
+
+			UE_LOG(LogTemp , Warning, TEXT("서버 열기 요청 : %s"), *TravelURL);
+		}
+	}
+
+	UE_LOG(LogTemp, Warning, TEXT("New Game 버튼 클릭: 로비 맵으로 이동 시도"));
+}
+
+void UMainMenuWidget::OnSearchMatchClicked()
+{
+	UE_LOG(LogTemp, Warning, TEXT("SearchMatch 버튼 클릭: 세션 찾기 맵으로 이동 시도"));
+}
+
+void UMainMenuWidget::OnOptionsClicked()
+{
+	UE_LOG(LogTemp, Warning, TEXT("Options 버튼 클릭: 옵션 창으로 이동 시도"));
+}
+
+void UMainMenuWidget::OnCreditsClicked()
+{
+	UE_LOG(LogTemp, Warning, TEXT("Credits 버튼 클릭: 크레딧 창으로 이동 시도"));
+}
+
+void UMainMenuWidget::OnQuitClicked()
+{
+	if (UWorld* World = GetWorld())
+	{
+		APlayerController* PC = UGameplayStatics::GetPlayerController(World, 0);
+
+		if (PC)
+		{
+			UKismetSystemLibrary::QuitGame(World, PC, EQuitPreference::Quit, false);
+		}
+	}
+	UE_LOG(LogTemp, Warning, TEXT("Quit 버튼 클릭 : 게임 종료 시도"));
+}

--- a/Source/SF/UI/MainMenu/MainMenuWidget.h
+++ b/Source/SF/UI/MainMenu/MainMenuWidget.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Blueprint/UserWidget.h"
+#include "UI/Common/CommonButtonBase.h"
+
+#include "MainMenuWidget.generated.h"
+
+UCLASS()
+class SF_API UMainMenuWidget : public UUserWidget
+{
+	GENERATED_BODY()
+
+public:
+	virtual void NativeConstruct() override;
+
+protected:
+	// ------------- Button -------------
+	UPROPERTY(meta = (BindWidget))
+	UCommonButtonBase* Btn_NewGame;
+
+	UPROPERTY(meta = (BindWidget))
+	UCommonButtonBase* Btn_SearchMatch;
+
+	UPROPERTY(meta = (BindWidget))
+	UCommonButtonBase* Btn_Options;
+
+	UPROPERTY(meta = (BindWidget))
+	UCommonButtonBase* Btn_Credits;
+
+	UPROPERTY(meta = (BindWidget))
+	UCommonButtonBase* Btn_Quit;
+
+	// ------------- Game Flow -------------
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Game Flow")
+	TSoftObjectPtr<UWorld> LobbyMapAsset;
+
+	// ------------- Function -------------
+	UFUNCTION()
+	void OnNewGameClicked();
+
+	UFUNCTION()
+	void OnSearchMatchClicked();
+
+	UFUNCTION()
+	void OnOptionsClicked();
+
+	UFUNCTION()
+	void OnCreditsClicked();
+	
+	UFUNCTION()
+	void OnQuitClicked();
+	
+};


### PR DESCRIPTION
WBP_MainMenu의 로직을 담당하는 MainMenuWidget h/cpp 파일 추가

- MainMenuWidget h/cpp 파일 추가 및 버튼 클릭 델리게이트 연동
- 로비로 이동시 향후 호환성 및 확장성을 위해서 NewGame 클릭시 이동하는 맵을에디터에서 수정할 수 있도록 구현 (LobbyMapAsset)
- Project Settings 에서 에디터 시작 맵을 L_MainMenu 로 설정을 변경