### PR TITLE
Feat: 몬스터 AI 체력 바 위젯 위치 및 색상 수정 (임시)

### DIFF
--- a/Source/SF/Character/Enemy/Component/SFEnemyWidgetComponent.cpp
+++ b/Source/SF/Character/Enemy/Component/SFEnemyWidgetComponent.cpp
@@ -7,6 +7,7 @@
 #include "AbilitySystem/Attributes/Enemy/SFPrimarySet_Enemy.h"
 #include "GameFramework/PlayerController.h"
 #include "Camera/PlayerCameraManager.h"
+#include "Components/CapsuleComponent.h"
 #include "UI/Common/CommonBarBase.h"
 
 
@@ -79,8 +80,21 @@ void USFEnemyWidgetComponent::InitializeWidget()
         }
     }
 
+    // 이 컴포넌트의 주인(몬스터)이 캐릭터인지 확인
+    ACharacter* OwnerCharacter = Cast<ACharacter>(GetOwner());
+    if (OwnerCharacter && OwnerCharacter->GetCapsuleComponent())
+    {
+        // 캡슐의 절반 높이 (중심에서 머리끝까지)를 가져옴
+        float CapsuleHalfHeight = OwnerCharacter->GetCapsuleComponent()->GetScaledCapsuleHalfHeight();
+
+        // 위젯의 새로운 위치 설정
+        // X, Y는 0 (중앙), Z는 캡슐 높이 + 우리가 설정한 여유 공간(Offset)
+        SetRelativeLocation(FVector(0.f, 0.f, CapsuleHalfHeight + WidgetVerticalOffset));
+    }
+    
     if (EnemyWidget)
     {
+        EnemyWidget->SetBarColor(HealthBarColor);
         EnemyWidget->SetPercentVisuals(1.f);
     }
 }

--- a/Source/SF/Character/Enemy/Component/SFEnemyWidgetComponent.h
+++ b/Source/SF/Character/Enemy/Component/SFEnemyWidgetComponent.h
@@ -61,6 +61,15 @@ private:
 	TObjectPtr<UCommonBarBase> EnemyWidget;
 
 	// 표시 관련
+
+	// 캡슐 상단에서 얼마나 더 위로 띄울지 (기본값 50)
+	UPROPERTY(EditAnywhere, Category = "SF|Widget")
+	float WidgetVerticalOffset = 50.0f;
+
+	// 향후 에디터에서 몬스터마다 색상을 다르게 지정할 수 있게 변수 추가
+	UPROPERTY(EditAnywhere, Category = "SF|Widget")
+	FLinearColor HealthBarColor = FLinearColor::Red; // 기본값 빨강
+	
 	UPROPERTY(EditAnywhere, Category = "SF|Widget")
 	float VisibleDurationAfterHit = 3.f;
 

--- a/Source/SF/UI/Common/CommonBarBase.cpp
+++ b/Source/SF/UI/Common/CommonBarBase.cpp
@@ -43,6 +43,16 @@ void UCommonBarBase::SetPercentVisuals(float InPercent)
 	}
 }
 
+void UCommonBarBase::SetBarColor(FLinearColor NewColor)
+{
+	BarFillColor = NewColor;
+
+	if (PB_Current)
+	{
+		PB_Current->SetFillColorAndOpacity(BarFillColor);
+	}
+}
+
 void UCommonBarBase::NativeTick(const FGeometry& MyGeometry, float InDeltaTime)
 {
 	Super::NativeTick(MyGeometry, InDeltaTime);

--- a/Source/SF/UI/Common/CommonBarBase.h
+++ b/Source/SF/UI/Common/CommonBarBase.h
@@ -45,4 +45,7 @@ public:
 	// InGameHUD 호출용 함수 (0.0 ~ 1.0 사이의 수치로 UI 프로그래스바 수치 조절)
 	UFUNCTION(BlueprintCallable, Category="UI|Function")
 	void SetPercentVisuals(float InPercent);
+
+	// 외부(Component)에서 색상을 바꿀 수 있게 해주는 함수
+	void SetBarColor(FLinearColor NewColor);
 };


### PR DESCRIPTION
몬스터 AI의 체력 바 위젯 생성 위치 및 색상을 임시로 수정

- SFEnemyWidgetComponent 상에서 캡슐의 절반 높이로 몬스터 위에 체력 위젯을 띄우도록 로직 수정
- 임시로 Cpp 하드코딩으로 체력 바 색상 변경 가능하도록 수정
- CommonBarBase에서 Cpp 상에서 색상을 수정할 수 있도록 임시로 함수 추가