### PR TITLE
Feat: LobbyMap 리디자인

### DIFF
--- a/Content/Maps/L_Lobby_LJG.umap
+++ b/Content/Maps/L_Lobby_LJG.umap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dfff8aa9e51cdcaeb691c5a6beee279ea133c93a69cd415db4c451ecdd497079
+size 561323

--- a/Content/Maps/L_TestLobby_KMY.umap
+++ b/Content/Maps/L_TestLobby_KMY.umap
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4d40ab850c51b28afc7175305c2355a06ef703d2198a98cf3a8cc5b4d9dfe18f
-size 55669

--- a/Content/UI/Overlay/Common/WBP_SkillSlot.uasset
+++ b/Content/UI/Overlay/Common/WBP_SkillSlot.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:36e486cb144a3c91e8f3f223a9c374dccc94d7fbc03101bca9d4f7938ff5dce8
-size 30602
+oid sha256:ae47e24d451bcbd97a36e8188d6d55af942c20492e3e2bb9fffd40b7d3e7fcef
+size 42115

--- a/Source/SF/Player/Lobby/SFLobbyPlayerController.cpp
+++ b/Source/SF/Player/Lobby/SFLobbyPlayerController.cpp
@@ -3,6 +3,9 @@
 #include "SFLobbyPlayerState.h"
 #include "System/SFGameInstance.h"
 
+#include "Kismet/GameplayStatics.h"
+#include "GameFramework/Actor.h"
+
 ASFLobbyPlayerController::ASFLobbyPlayerController()
 {
 	bAutoManageActiveCameraTarget = false;
@@ -11,6 +14,24 @@ ASFLobbyPlayerController::ASFLobbyPlayerController()
 void ASFLobbyPlayerController::BeginPlay()
 {
 	Super::BeginPlay();
+
+	// 1. "LobbyCam" 태그가 달린 액터 검색
+	TArray<AActor*> FoundActors;
+	UGameplayStatics::GetAllActorsWithTag(GetWorld(), FName("LobbyCam"), FoundActors);
+
+	if (FoundActors.Num() > 0)
+	{
+		AActor* TargetCamera = FoundActors[0];
+
+		// 시점(View Target)을 카메라로 고정, blendTime 0.0f로 즉시 전환
+		SetViewTargetWithBlend(TargetCamera, 0.0f);
+
+		UE_LOG(LogTemp, Log, TEXT("Camera Set directly to LobbyCam."));		
+	}
+	else
+	{
+		UE_LOG(LogTemp, Warning, TEXT("Failed to find Actor with tag 'LobbyCam'. Check your Level"));
+	}
 }
 
 void ASFLobbyPlayerController::Server_RequestStartMatch_Implementation()


### PR DESCRIPTION
LobbyMap 리디자인 및 LobbyPlayerController 카메라 연결 로직 추가

- 새로운 LobbyMap (L_Lobby_LJG) 생성
- 기존 임시 로비맵 (L_TestLobby_KMY) 삭제
- LobbyPlayerController상에서 LobbyMap 입장 시 카메라 연결 로직 추가
- 임시 테스트 용으로 WBP_SkillSlot 이미지 임시 지정