### PR TITLE
feat : 플레이어 이름 표시 기능 추가

### DIFF
--- a/Config/DefaultEngine.ini
+++ b/Config/DefaultEngine.ini
@@ -115,6 +115,7 @@ ManualIPAddress=
 +ClassRedirects=(OldName="/Script/SF.SFGA_Hero",NewName="/Script/SF.SFGA_Hero_AreaHeal_C")
 +PropertyRedirects=(OldName="/Script/SF.CommonBarBase.SizeBox",NewName="/Script/SF.CommonBarBase.DynamicSizeBox")
 +ClassRedirects=(OldName="/Script/SF.SFGA_EnemyDeath",NewName="/Script/SF.SFGA_CharacterDeath")
++PropertyRedirects=(OldName="/Script/SF.SFPlayerController.TeammateIndicatorWidgets",NewName="/Script/SF.SFPlayerController.TeammateWidgetMap")
 
 
 [/Script/Engine.NetworkSettings]

--- a/Content/Player/BP_SFPlayerController.uasset
+++ b/Content/Player/BP_SFPlayerController.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b5b3b112c6ceb6647b28b3596760a46ecbed469d45c2ab66bb9a15ea695bd54d
-size 22076
+oid sha256:a1d9ba3c12f4f688ddf8e9f5459431f3820c0d71af244126904e625b4651771f
+size 22308

--- a/Content/UI/Assets/Icons/T_UI_Indicator_Arrow.uasset
+++ b/Content/UI/Assets/Icons/T_UI_Indicator_Arrow.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e4cd01302a926ee385ee03e303e2be8232e56b58928eb020e131aaa4db28e663
+size 19431

--- a/Content/UI/Overlay/Common/WBP_TeammateIndicator.uasset
+++ b/Content/UI/Overlay/Common/WBP_TeammateIndicator.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f04d9f37f0c6de644960d3786c2a60701a91723cfa525347e8882fa75a553e29
+size 17858

--- a/SF.uproject
+++ b/SF.uproject
@@ -12,7 +12,8 @@
 				"GameplayAbilities",
 				"ModularGameplay",
 				"Engine",
-				"AIModule"
+				"AIModule",
+				"UMG"
 			]
 		}
 	],
@@ -56,15 +57,15 @@
 			"Name": "AnimationWarping",
 			"Enabled": true
 		},
-    {
-        "Name": "GameplayMessageRouter",
-        "Enabled": true
-    },
-    {
-        "Name": "MotionWarping",
-        "Enabled": true
-    },
-    {
+		{
+			"Name": "GameplayMessageRouter",
+			"Enabled": true
+		},
+		{
+			"Name": "MotionWarping",
+			"Enabled": true
+		},
+		{
 			"Name": "CommonLoadingScreen",
 			"Enabled": true
 		}

--- a/Source/SF/Player/SFPlayerController.h
+++ b/Source/SF/Player/SFPlayerController.h
@@ -38,8 +38,6 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "SF|PlayerController")
 	USFAbilitySystemComponent* GetSFAbilitySystemComponent() const;
 
-	
-
 protected:
 	virtual void PostProcessInput(const float DeltaTime, const bool bGamePaused) override;
 
@@ -60,7 +58,23 @@ protected:
 	UPROPERTY()
 	TObjectPtr<UUserWidget> InGameMenuInstance;
 
+	// 팀원 표시 위젯 클래스
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "UI|InGame")
+	TSubclassOf<UUserWidget> TeammateIndicatorWidgetClass;
+
+	// 생성된 팀원 표시 위젯 관리 맵
+	UPROPERTY()
+	TMap<AActor*, class USFIndicatorWidgetBase*> TeammateWidgetMap;
+
+	// 팀원 표시 검색 타이머 핸들
+	FTimerHandle TeammateSearchTimerHandle;
+	
+
+protected:
+	// 인게임 메뉴 생성 함수
 	void ToggleInGameMenu();
+	// 팀원 위젯 생성 함수
+	void CreateTeammateIndicators();
 
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "UI|SkillSelection")
 	TSubclassOf<USFSkillSelectionScreen> SkillSelectionScreenClass;

--- a/Source/SF/UI/InGame/SFIndicatorWidgetBase.cpp
+++ b/Source/SF/UI/InGame/SFIndicatorWidgetBase.cpp
@@ -1,0 +1,210 @@
+#include "UI/InGame/SFIndicatorWidgetBase.h"
+
+#include "Components/Image.h"
+#include "Components/TextBlock.h"
+#include "Components/CanvasPanelSlot.h"
+#include "Components/Widget.h"
+#include "Blueprint/WidgetLayoutLibrary.h"
+#include "Kismet/GameplayStatics.h"
+#include "Kismet/KismetMathLibrary.h"
+#include "GameFramework/PlayerState.h"
+#include "GameFramework/Pawn.h"
+
+void USFIndicatorWidgetBase::NativeConstruct()
+{
+	Super::NativeConstruct();
+
+	// 자주 쓰는 Canvas Slot을 미리 캐싱해둠 (매번 Cast 안 하도록)
+	if (IndicatorRoot)
+	{
+		RootCanvasSlot = UWidgetLayoutLibrary::SlotAsCanvasSlot(IndicatorRoot);
+	}
+	
+}
+
+void USFIndicatorWidgetBase::NativeTick(const FGeometry& MyGeometry, float InDeltaTime)
+{
+	Super::NativeTick(MyGeometry, InDeltaTime);
+
+	// 1. 필수 컴포넌트 유효성 검사
+	if (!IndicatorRoot || !ArrowImage || !NameText || !RootCanvasSlot)
+	{
+		return;
+	}
+
+	// 2. 핵심 로직 함수 호출
+	UpdateIndicatorTransform();
+}
+
+void USFIndicatorWidgetBase::SetTargetActor(AActor* InTargetActor)
+{
+	TargetActorPtr = InTargetActor;
+
+	// 타겟이 들어오면 이름표 미리 세팅
+	UpdatePlayerName();
+}
+
+void USFIndicatorWidgetBase::UpdatePlayerName()
+{
+	AActor* Target = TargetActorPtr.Get();
+	if (!Target || !NameText) return;
+
+	if (APawn* TargetPawn = Cast<APawn>(Target))
+	{
+		// PlayerState가 생성되었는지 확인
+		if (APlayerState* PS = TargetPawn->GetPlayerState())
+		{
+			FString PlayerName = PS->GetPlayerName();
+			// 유효한 이름이 들어왔을 때만 텍스트 설정
+			if (!PlayerName.IsEmpty())
+			{
+				NameText->SetText(FText::FromString(PlayerName));
+			}
+		}
+		else
+		{
+			// PlayerState가 아직 없다면 -> 공백란
+			NameText->SetText(FText::GetEmpty());
+		}
+	}
+}
+
+void USFIndicatorWidgetBase::UpdateIndicatorTransform()
+{
+	AActor* Target = TargetActorPtr.Get();
+    APlayerController* PC = GetOwningPlayer();
+
+    // 1. 타겟/PC 유효성 검사
+    if (!Target || !PC)
+    {
+       SetRenderOpacity(0.0f);
+       return;
+    }
+    SetRenderOpacity(1.0f);
+
+    // 2. 위치 계산 (머리 위 +120.0f 보정)
+    FVector TargetLocation = Target->GetActorLocation() + FVector(0.0f, 0.0f, 120.0f);
+    FVector CameraLocation;
+    FRotator CameraRotation;
+    PC->GetPlayerViewPoint(CameraLocation, CameraRotation);
+
+	// 카메라와 타겟 사이의 거리 계산 (단위: cm)
+	float CamDistance = FVector::Dist(CameraLocation, TargetLocation);
+
+	// 거리 범위 설정 (예: 5m ~ 50m)
+	const float MinDistance = 500.0f;  // 가까울 때 (5m)
+	const float MaxDistance = 5000.0f; // 멀 때 (50m)
+
+	// 스케일 범위 설정 (1.0배 ~ 0.6배)
+	const float MinScale = 0.6f;
+	const float MaxScale = 1.0f;
+
+	// 거리를 스케일 값으로 매핑 (가까우면 MaxScale, 멀면 MinScale)
+	// GetMappedRangeValueClamped: 입력값이 범위 밖이어도 알아서 최소/최대로 설정
+	float DistanceScale = FMath::GetMappedRangeValueClamped(
+		FVector2D(MinDistance, MaxDistance),
+		FVector2D(MaxScale, MinScale),
+		CamDistance
+		);
+
+	// 위젯 전체 루트에 스케일 적용
+	IndicatorRoot->SetRenderScale(FVector2D(DistanceScale, DistanceScale));
+	
+    // 3. 월드 -> 스크린 변환
+    FVector2D ScreenPosition;
+    bool bIsOnScreen = UGameplayStatics::ProjectWorldToScreen(PC, TargetLocation, ScreenPosition);
+
+    // 4. 뷰포트 크기 및 DPI 스케일 적용
+    int32 SizeX, SizeY;
+    PC->GetViewportSize(SizeX, SizeY);
+    FVector2D ViewportSize(SizeX, SizeY);
+
+    float Scale = UWidgetLayoutLibrary::GetViewportScale(this);
+    if (Scale > 0.0f)
+    {
+       ScreenPosition /= Scale;
+       ViewportSize /= Scale;
+    }
+    FVector2D ScreenCenter = ViewportSize / 2.0f;
+
+    // 5. 화면 밖 / 카메라 뒤 판정
+    FVector DirectionToTarget = (TargetLocation - CameraLocation).GetSafeNormal();
+    FVector LocalDirection = CameraRotation.UnrotateVector(DirectionToTarget);
+
+    bool bIsBehind = LocalDirection.X < 0.0f;
+    bool bIsWayOut = (ScreenPosition.X < -ScreenEdgeMargin || ScreenPosition.X > ViewportSize.X + ScreenEdgeMargin ||
+                      ScreenPosition.Y < -ScreenEdgeMargin || ScreenPosition.Y > ViewportSize.Y + ScreenEdgeMargin);
+
+    bool bIsOffScreen = !bIsOnScreen || bIsBehind || bIsWayOut;
+
+    // 6. 최종 좌표 및 회전 계산
+    float RotationAngle = 0.0f;
+
+    if (bIsOffScreen)
+    {
+       // === [화면 밖] ===
+       FVector2D Direction2D(LocalDirection.Y, LocalDirection.Z * -1.0f);
+       if (Direction2D.IsNearlyZero()) Direction2D = FVector2D(1, 0);
+       Direction2D.Normalize();
+
+       float Radians = FMath::Atan2(Direction2D.Y, Direction2D.X);
+       RotationAngle = FMath::RadiansToDegrees(Radians);
+
+       float AngleCos = FMath::Cos(Radians);
+       float AngleSin = FMath::Sin(Radians);
+
+    	FVector2D IndiWidgetSize = IndicatorRoot->GetDesiredSize();
+
+    	// 만약 첫 프레임이라 크기가 0이면 기본값(150, 30)으로 방어
+    	if (IndiWidgetSize.IsZero()) IndiWidgetSize = FVector2D(150.0f, 30.0f);
+
+    	// 화면 절반 크기에서 "마진"과 "위젯 절반 크기"를 각각 뺍니다.
+    	// 가로 벽 거리 = (화면가로/2) - (위젯가로/2) - 마진
+    	float BoundX = (ViewportSize.X / 2.0f) - (IndiWidgetSize.X / 2.0f) - ScreenEdgeMargin;
+    	// 세로 벽 거리 = (화면세로/2) - (위젯세로/2) - 마진
+    	float BoundY = (ViewportSize.Y / 2.0f) - (IndiWidgetSize.Y / 2.0f) - ScreenEdgeMargin;
+
+    	// 혹시 마진이 너무 커서 음수가 되면 0으로 고정 (안전장치)
+    	BoundX = FMath::Max(BoundX, 0.0f);
+    	BoundY = FMath::Max(BoundY, 0.0f);
+
+    	// 기울기(Slope)를 이용해 부딪히는 지점 계산 (y = mx)
+    	// Cos가 0에 가까우면(수직) 무한대가 되므로 예외처리
+    	float DistToVerticalEdge = (AngleCos != 0.0f) ? FMath::Abs(BoundX / AngleCos) : 999999.0f;
+    	float DistToHorizontalEdge = (AngleSin != 0.0f) ? FMath::Abs(BoundY / AngleSin) : 999999.0f;
+
+    	// 둘 중 더 빨리 벽에 닿는 거리를 선택
+    	float FinalDistance = FMath::Min(DistToVerticalEdge, DistToHorizontalEdge);
+
+    	// 최종 좌표 확정
+    	ScreenPosition = ScreenCenter + (FVector2D(AngleCos, AngleSin) * FinalDistance);
+
+    	// 비주얼 업데이트 (화면 밖)
+    	ArrowImage->SetVisibility(ESlateVisibility::Visible);
+    	ArrowImage->SetRenderTransformAngle(RotationAngle + 90.0f);
+    	NameText->SetVisibility(ESlateVisibility::Visible);
+    }
+    else
+    {
+       // === [화면 안] ===
+       ArrowImage->SetVisibility(ESlateVisibility::Hidden);
+       NameText->SetVisibility(ESlateVisibility::Visible);
+
+       // 이름 업데이트 (함수 재활용)
+       if (NameText->GetText().IsEmpty())
+       {
+           UpdatePlayerName();
+       }
+
+       ArrowImage->SetRenderTransformAngle(0.0f);
+    }
+
+	// 이름 업데이트 시도 (아직 안 떴을 경우 대비)
+	if (NameText->GetText().IsEmpty())
+	{
+		UpdatePlayerName();
+	}
+
+    // 7. 이동
+    RootCanvasSlot->SetPosition(ScreenPosition);
+}

--- a/Source/SF/UI/InGame/SFIndicatorWidgetBase.h
+++ b/Source/SF/UI/InGame/SFIndicatorWidgetBase.h
@@ -1,0 +1,60 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Blueprint/UserWidget.h"
+#include "SFIndicatorWidgetBase.generated.h"
+
+class UImage;
+class UTextBlock;
+class UWidget;
+class UCanvasPanelSlot;
+
+/**
+ * 팀원 위치 표시기용 베이스 위젯
+ */
+
+UCLASS()
+class SF_API USFIndicatorWidgetBase : public UUserWidget
+{
+	GENERATED_BODY()
+
+public:
+	// 타겟 설정 함수
+	void SetTargetActor(AActor* InTargetActor);
+	// 플레이어 이름 업데이트 함수
+	void UpdatePlayerName();
+	// 위젯 위치 및 회전 함수
+	void UpdateIndicatorTransform();
+	// 타겟(Actor)이 메모리에서 사라졌는지 확인하는 헬퍼 함수
+	bool HasValidTarget() const { return TargetActorPtr.IsValid(); }
+
+protected:
+	virtual void NativeConstruct() override;
+	virtual void NativeTick(const FGeometry& MyGeometry, float InDeltaTime) override;
+
+protected:
+	// 추적 대상 (약한 참조)
+	TWeakObjectPtr<AActor> TargetActorPtr;
+
+	// 화면 가장자리 여백 (픽셀)
+	UPROPERTY(EditDefaultsOnly, Category = "UI|InGame")
+	float ScreenEdgeMargin = 150.0f;
+
+	UPROPERTY(meta = (BindWidget))
+	TObjectPtr<UWidget> IndicatorRoot; // 위치를 이동시킬 부모 컨테이너
+
+	UPROPERTY(meta = (BindWidget))
+	TObjectPtr<UImage> ArrowImage;     // 화살표 이미지
+
+	UPROPERTY(meta = (BindWidget))
+	TObjectPtr<UTextBlock> NameText;   // 이름 텍스트
+
+private:
+	// 성능 최적화를 위해 슬롯을 캐싱
+	UPROPERTY()
+	TObjectPtr<UCanvasPanelSlot> RootCanvasSlot;
+	
+
+};


### PR DESCRIPTION
타 플레이어가 시야 안에 있을 경우 -> 플레이어 이름 표기
타 플레이어가 시야 밖에 있을 경우 -> 플레이어 이름과 해당 위치 화살표 이미지로 표시

- 화면 표시용 위젯 WBP_TeammateIndicator 추가
- 해당 위젯에서 사용되는 이미지 텍스쳐 추가
- 해당 위젯의 로직을 담당할 SFIndicatorWidgetBase.h/cpp 추가
- 위젯의 실시간 연산(위치/거리/이름/방향)을 위해 SFPlayerController에 함수/타이머 추가
- CreateTeammateIndicator()
- TeammateSearchTimerHandle

변경된 주요 파일 :  SFPlayerController.h / SFPlayerController.cpp / BP_SFPlayerController