### PR TITLE
fix:버그 픽스 및 위젯 스케일 조정

### DIFF
--- a/Content/Character/Enemy/Enemys/Elite/01/BP_Elite01.uasset
+++ b/Content/Character/Enemy/Enemys/Elite/01/BP_Elite01.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9e4482f8ba09b8cdd2330c0a08b41261a65e56c27112af63eaa6cbb1c1c9c369
-size 50882
+oid sha256:9930a6031f9424be9a4b98192b596408e08ee490beb4f2f0b517c97cd57d6fff
+size 50560

--- a/Content/GameModes/BP_SFGameMode.uasset
+++ b/Content/GameModes/BP_SFGameMode.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e392cd6f2628d22f6b16a77eccb39cdfd874a70be69f8a28f22fe98f5db25d98
+oid sha256:9584a5e86f54061edbfae39dce9e535b7ee809d95ad130bf1f5d601342430c85
 size 22460

--- a/Content/Player/BP_SFPlayerController.uasset
+++ b/Content/Player/BP_SFPlayerController.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b87cca42e6d2f20bd903bae745a5851cdebe4d15eef9f6244161d1e4b9907b21
-size 274
+oid sha256:67bad1a5dd8a155e41ffca6b4cc777b4bf3f323963a9c245404cb957cb22b125
+size 25991

--- a/Source/SF/AbilitySystem/Attributes/SFPrimarySet.cpp
+++ b/Source/SF/AbilitySystem/Attributes/SFPrimarySet.cpp
@@ -8,14 +8,10 @@
 #include "AbilitySystem/GameplayEvent/SFGameplayEventTags.h"
 #include "Character/SFCharacterGameplayTags.h"
 #include "Libraries/SFAbilitySystemLibrary.h"
-<<<<<<< Updated upstream
 #include "Player/SFPlayerState.h"
 #include "Player/Components/SFPlayerStatsComponent.h"
-
-=======
 #include "GameFramework/GameplayMessageSubsystem.h"
 #include "UI/InGame/UIDataStructs.h"
->>>>>>> Stashed changes
 
 USFPrimarySet::USFPrimarySet()
 {

--- a/Source/SF/Player/SFPlayerController.cpp
+++ b/Source/SF/Player/SFPlayerController.cpp
@@ -16,11 +16,8 @@
 #include "Components/SFSpectatorComponent.h"
 #include "Components/CapsuleComponent.h"
 #include "GameFramework/Character.h"
-<<<<<<< Updated upstream
 #include "GameModes/SFGameOverManagerComponent.h"
-=======
 #include "GameFramework/GameplayMessageSubsystem.h"
->>>>>>> Stashed changes
 #include "Kismet/GameplayStatics.h"
 #include "Pawn/SFSpectatorPawn.h"
 #include "System/SFPlayFabSubsystem.h"


### PR DESCRIPTION
각종 에러 수정 및 몬스터 캡슐 컴포넌트 스케일 조정

- 엘리트 몬스터 캡슐 컴포넌트 스케일 조정
- 데미지 텍스트 UI 기능 구현 중 깃 버전관리 상 문제로 생긴 빌드에러 수정
- 깃 lfs 연결 해제로 소실된 BP_ SFPlayerController 파일 복구 및 BP_SFGameModes 의 PC 재설정