### PR TITLE
feat:로비 인게임 메뉴 기능 추가 및 리팩토링

### DIFF
--- a/Content/Input/IMC_MenuUI.uasset
+++ b/Content/Input/IMC_MenuUI.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:863961c5f24cb11fc60786641bc179aa6b2fec9ec1d231f38f99b6b024780f23
+size 2146

--- a/Content/Player/BP_SFPlayerController.uasset
+++ b/Content/Player/BP_SFPlayerController.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:67bad1a5dd8a155e41ffca6b4cc777b4bf3f323963a9c245404cb957cb22b125
-size 25991
+oid sha256:7cbc366dc4bf067f323d6eed026b0b877934cb9bf3f5973ad15686b1ad231c43
+size 26322

--- a/Content/Player/Lobby/BP_SFLobbyPlayerController.uasset
+++ b/Content/Player/Lobby/BP_SFLobbyPlayerController.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:81f7db00e80b5007ffb6219c174cdd2713448a8c361cbecebfd00ccc8da9c86e
-size 22258
+oid sha256:886ba77f55ef325846d0bbc94c96dd467e971d16c0f9710085e83efd7fce9699
+size 23216

--- a/Content/UI/Options/WBP_OptionMenu.uasset
+++ b/Content/UI/Options/WBP_OptionMenu.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8e371d4041fb8dd76c60efc95b2f8f0033e688503edda94ed7d30d90cd2ab684
-size 434712
+oid sha256:70524d4696e8542b23d63ee272f8391db6ca9efee7a22296556206ba7b0e7053
+size 456582

--- a/Source/SF/Player/Lobby/SFLobbyPlayerController.cpp
+++ b/Source/SF/Player/Lobby/SFLobbyPlayerController.cpp
@@ -2,13 +2,27 @@
 
 #include "SFLobbyPlayerState.h"
 #include "System/SFGameInstance.h"
+#include "UI/Compoent/SFInGameMenuComponent.h"
 
 #include "Kismet/GameplayStatics.h"
 #include "GameFramework/Actor.h"
+#include "EnhancedInputComponent.h"
 
 ASFLobbyPlayerController::ASFLobbyPlayerController()
 {
 	bAutoManageActiveCameraTarget = false;
+	InGameMenuComponent = CreateDefaultSubobject<USFInGameMenuComponent>(TEXT("InGameMenuComponent"));
+}
+
+void ASFLobbyPlayerController::SetupInputComponent()
+{
+	Super::SetupInputComponent();
+
+	// 컴포넌트 -> 입력 바인딩 위임
+	if (UEnhancedInputComponent* EnhancedInputComponent = Cast<UEnhancedInputComponent>(InputComponent))
+	{
+		InGameMenuComponent->SetupInputBindings(EnhancedInputComponent);
+	}
 }
 
 void ASFLobbyPlayerController::BeginPlay()
@@ -32,6 +46,10 @@ void ASFLobbyPlayerController::BeginPlay()
 	{
 		UE_LOG(LogTemp, Warning, TEXT("Failed to find Actor with tag 'LobbyCam'. Check your Level"));
 	}
+
+	SetInputMode(FInputModeGameAndUI());
+	SetShowMouseCursor(true);
+	
 }
 
 void ASFLobbyPlayerController::Server_RequestStartMatch_Implementation()

--- a/Source/SF/Player/Lobby/SFLobbyPlayerController.h
+++ b/Source/SF/Player/Lobby/SFLobbyPlayerController.h
@@ -14,6 +14,7 @@ class SF_API ASFLobbyPlayerController : public ASFMenuPlayerController
 
 public:
 	ASFLobbyPlayerController();
+	virtual void SetupInputComponent() override;
 
 	UFUNCTION(Server, Reliable, WithValidation)
 	void Server_RequestStartMatch();
@@ -24,4 +25,7 @@ public:
 protected:
 	virtual void BeginPlay() override;
 
+private:
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "UI|Components", meta = (AllowPrivateAccess = "true"))
+	TObjectPtr<class USFInGameMenuComponent> InGameMenuComponent;
 };

--- a/Source/SF/Player/SFPlayerController.h
+++ b/Source/SF/Player/SFPlayerController.h
@@ -11,6 +11,7 @@
 class USFSharedUIComponent;
 class USFDeathUIComponent;
 class USFSpectatorComponent;
+class USFInGameMenuComponent;
 struct FSFStageInfo;
 class USFSkillSelectionScreen;
 class USFLoadingCheckComponent;
@@ -18,8 +19,6 @@ class ASFPlayerState;
 class USFAbilitySystemComponent;
 class UUserWidget;
 class USFDamageWidget;
-class UInputAction;
-class UInputMappingContext;
 
 /**
  * 
@@ -67,9 +66,6 @@ protected:
 	
 	UFUNCTION(Server, Unreliable)
 	void Server_UpdateViewRotation(FRotator NewRotation);
-
-	// 인게임 메뉴 생성 함수
-	void ToggleInGameMenu();
 	
 	// 팀원 위젯 생성 함수
 	void CreateTeammateIndicators();
@@ -88,22 +84,6 @@ protected:
 	void Server_NotifyReadyForLobby();
 
 protected:
-	// ----------------[추가] 인게임 메뉴 관련 변수 및 함수----------------------
-
-	// 에디터 상에서 지정할 IA_InGameMenu 변수
-	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "UI|Input")
-	TObjectPtr<UInputAction> InGameMenuAction;
-
-	// 에디터 상에서 지정할 IMC 변수
-	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "UI|Input")
-	TObjectPtr<UInputMappingContext> DefaultMappingContext;
-	
-	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "UI|InGame")
-	TSubclassOf<UUserWidget> InGameMenuClass;
-
-	UPROPERTY()
-	TObjectPtr<UUserWidget> InGameMenuInstance;
-
 	// 팀원 표시 위젯 클래스
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "UI|InGame")
 	TSubclassOf<UUserWidget> TeammateIndicatorWidgetClass;
@@ -127,6 +107,9 @@ private:
 
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "SF|Components", meta = (AllowPrivateAccess = "true"))
 	TObjectPtr<USFSharedUIComponent> SharedUIComponent;
+
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "SF|Components", meta = (AllowPrivateAccess = "true"))
+	TObjectPtr<USFInGameMenuComponent> InGameMenuComponent; 
 
 private:
 	// ViewRotation 전송 최적화 

--- a/Source/SF/UI/Compoent/SFInGameMenuComponent.cpp
+++ b/Source/SF/UI/Compoent/SFInGameMenuComponent.cpp
@@ -1,0 +1,92 @@
+#include "UI/Compoent/SFInGameMenuComponent.h"
+
+#include "UI/InGame/SFInGameMenuWidget.h"
+
+#include "EnhancedInputComponent.h"
+#include "EnhancedInputSubsystems.h"
+#include "GameFramework/PlayerController.h"
+#include "Kismet/GameplayStatics.h"
+
+
+USFInGameMenuComponent::USFInGameMenuComponent()
+{
+	PrimaryComponentTick.bCanEverTick = false;
+
+}
+
+void USFInGameMenuComponent::BeginPlay()
+{
+	Super::BeginPlay();
+
+	if (APlayerController* PC = Cast<APlayerController>(GetOwner()))
+	{
+		if (UEnhancedInputLocalPlayerSubsystem* Subsystem =
+			ULocalPlayer::GetSubsystem<UEnhancedInputLocalPlayerSubsystem>(PC->GetLocalPlayer()))
+		{
+			if (InGameMenuMappingContext)
+			{
+				Subsystem->AddMappingContext(InGameMenuMappingContext, 100);
+			}
+		}
+	}
+}
+
+void USFInGameMenuComponent::EndPlay(const EEndPlayReason::Type EndPlayReason)
+{
+	// 레벨 전환되거나 PC 파괴될 때 위젯 정리
+	if (InGameMenuInstance)
+	{
+		if (InGameMenuInstance->IsInViewport())
+		{
+			InGameMenuInstance->RemoveFromParent();
+		}
+		InGameMenuInstance = nullptr;
+	}
+	Super::EndPlay(EndPlayReason);
+}
+
+void USFInGameMenuComponent::SetupInputBindings(UEnhancedInputComponent* PlayerInputComponent)
+{
+	if (!PlayerInputComponent || !InGameMenuAction) return;
+
+	// 인풋 액션 바인딩
+	PlayerInputComponent->BindAction(InGameMenuAction, ETriggerEvent::Started, this, &USFInGameMenuComponent::ToggleInGameMenu);
+}
+
+void USFInGameMenuComponent::ToggleInGameMenu()
+{
+	APlayerController* PC = Cast<APlayerController>(GetOwner());
+	if (!PC) return;
+
+	UE_LOG(LogTemp, Log, TEXT("[SFSystemMenuComponent] Toggle Menu Request"));
+
+	// 1. 이미 켜져 있으면 끄기
+	if (InGameMenuInstance && InGameMenuInstance->IsInViewport())
+	{
+		InGameMenuInstance->RemoveFromParent();
+		InGameMenuInstance = nullptr;
+
+		PC->SetInputMode(FInputModeGameOnly());
+		PC->bShowMouseCursor = false;
+		return;
+	}
+	
+	// 2. 꺼져 있으면 켜기
+	if (InGameMenuClass)
+	{
+		InGameMenuInstance = CreateWidget<USFInGameMenuWidget>(PC, InGameMenuClass);
+		if (InGameMenuInstance)
+		{
+			InGameMenuInstance->AddToViewport(100);
+
+			FInputModeUIOnly InputMode;
+			InputMode.SetWidgetToFocus(InGameMenuInstance->TakeWidget());
+			InputMode.SetLockMouseToViewportBehavior(EMouseLockMode::DoNotLock);
+
+			PC->SetInputMode(InputMode);
+			PC->bShowMouseCursor = true;
+		}
+	}
+}
+
+

--- a/Source/SF/UI/Compoent/SFInGameMenuComponent.h
+++ b/Source/SF/UI/Compoent/SFInGameMenuComponent.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Components/ActorComponent.h"
+#include "InputActionValue.h"
+#include "SFInGameMenuComponent.generated.h"
+
+class UInputAction;
+class UInputMappingContext;
+class UEnhancedInputComponent;
+
+/**
+ * 인게임 메뉴(ESC) 기능을 담당하는 컴포넌트
+ *  PlayerController부착 -> 인게임 메뉴 기능을 제공
+ */
+
+UCLASS( ClassGroup=(Custom), meta=(BlueprintSpawnableComponent) )
+class SF_API USFInGameMenuComponent : public UActorComponent
+{
+	GENERATED_BODY()
+
+public:	
+	USFInGameMenuComponent();
+
+protected:
+	virtual void BeginPlay() override;
+	virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
+
+public:
+	// PC의 SetupInputComponent에서 호출
+	void SetupInputBindings(UEnhancedInputComponent* PlayerInputComponent);
+
+	// 메뉴 토글
+	UFUNCTION(BlueprintCallable, Category = "UI|Menu")
+	void ToggleInGameMenu();
+
+protected:
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "UI|Menu")
+	TObjectPtr<UInputAction> InGameMenuAction;
+
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "UI|Menu")
+	TObjectPtr<UInputMappingContext> InGameMenuMappingContext;
+
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "UI|Menu")
+	TSubclassOf<class USFInGameMenuWidget> InGameMenuClass;
+
+private:
+	UPROPERTY()
+	TObjectPtr<class USFInGameMenuWidget> InGameMenuInstance;
+};

--- a/Source/SF/UI/InGame/SFInGameMenuWidget.cpp
+++ b/Source/SF/UI/InGame/SFInGameMenuWidget.cpp
@@ -4,6 +4,7 @@
 #include "GameFramework/PlayerController.h"
 
 #include "UI/Common/CommonButtonBase.h"
+#include "Player/Lobby/SFLobbyPlayerController.h"
 
 void USFInGameMenuWidget::NativeConstruct()
 {
@@ -39,8 +40,22 @@ void USFInGameMenuWidget::OnResumeClicked()
 
 	if (APlayerController* PC = GetOwningPlayer())
 	{
-		PC->SetInputMode(FInputModeGameOnly());
-		PC->bShowMouseCursor = false;
+		// 1. 로비 컨트롤러 = 로비 레벨 -> (IsA를 사용해 타입 검사)
+		if (PC->IsA(ASFLobbyPlayerController::StaticClass()))
+		{
+			FInputModeGameAndUI InputMode;
+			InputMode.SetLockMouseToViewportBehavior(EMouseLockMode::DoNotLock);
+			InputMode.SetHideCursorDuringCapture(false);
+			
+			PC->SetInputMode(InputMode);
+			PC->bShowMouseCursor = true;
+		}
+		// 2. 그 외(인게임)
+		else
+		{
+			PC->SetInputMode(FInputModeGameOnly());
+			PC->bShowMouseCursor = false;
+		}
 	}
 }
 
@@ -57,6 +72,8 @@ void USFInGameMenuWidget::OnOptionsClicked()
 	if (OptionsWidget)
 	{
 		OptionsWidget->AddToViewport(100);
+
+		OptionsWidget->SetKeyboardFocus();
 	}
 }
 

--- a/Source/SF/UI/MainMenu/MainMenuWidget.cpp
+++ b/Source/SF/UI/MainMenu/MainMenuWidget.cpp
@@ -86,6 +86,8 @@ void UMainMenuWidget::OnOptionsClicked()
 	if (OptionsWidget)
 	{
 		OptionsWidget->AddToViewport(100);
+
+		OptionsWidget->SetKeyboardFocus();
 	}
 }
 


### PR DESCRIPTION
인게임 메뉴를 인게임 뿐 아니라 로비에서도 사용할 수 있도록 리팩토링 및 버그 수정

- 기존 PC에서 게임메뉴를 띄우는 방식에서 ActorComponent를 PC에 부착하는 방식으로 리팩토링
- SFPlayerController 에서 해당 게임메뉴 띄우는 로직 삭제
- 새로운 IMC추가(IMC_MenuUI)
- 인게임 메뉴 전용 AC 추가 (SFInGameMenuCompoent.h/cpp)
- 옵션메뉴 키보드 포커스 관련 버그 수정 및 ESC키 입력시 뒤로가기 기능 추가(BP)