### PR TITLE
Feat: 어빌리티 커스텀 영구 데이터 저장 및 복원 기능 추가

### DIFF
--- a/Source/SF/AbilitySystem/Abilities/SFGameplayAbility.h
+++ b/Source/SF/AbilitySystem/Abilities/SFGameplayAbility.h
@@ -5,6 +5,7 @@
 #include "Abilities/GameplayAbility.h"
 #include "Animation/Hero/SFHeroAnimationData.h"
 #include "Character/Hero/Component/SFHeroMovementComponent.h"
+#include "StructUtils/InstancedStruct.h"
 #include "SFGameplayAbility.generated.h"
 
 class USFAbilityCost;
@@ -43,6 +44,15 @@ public:
 
 	virtual bool CheckCost(const FGameplayAbilitySpecHandle Handle, const FGameplayAbilityActorInfo* ActorInfo, FGameplayTagContainer* OptionalRelevantTags = nullptr) const override;
 	virtual void ApplyCost(const FGameplayAbilitySpecHandle Handle, const FGameplayAbilityActorInfo* ActorInfo, const FGameplayAbilityActivationInfo ActivationInfo) const override;
+
+	virtual FInstancedStruct SaveCustomPersistentData() const 
+	{ 
+		return FInstancedStruct(); // 빈 구조체 (데이터 없음)
+	}
+	virtual void RestoreCustomPersistentData(const FInstancedStruct& Data) {}
+	
+	// 커스텀 세이브 데이터 유무
+	virtual bool HasCustomPersistentData() const { return false; }
 
 	UFUNCTION(BlueprintCallable, Category = "SF|Ability")
 	USFAbilitySystemComponent* GetSFAbilitySystemComponentFromActorInfo() const;

--- a/Source/SF/Player/Save/SFPersistentDataType.h
+++ b/Source/SF/Player/Save/SFPersistentDataType.h
@@ -3,6 +3,7 @@
 #include "CoreMinimal.h"
 #include "AttributeSet.h"
 #include "GameplayTagContainer.h"
+#include "StructUtils/InstancedStruct.h"
 #include "SFPersistentDataType.generated.h"
 
 class UGameplayEffect;
@@ -34,6 +35,9 @@ struct FSFSavedAbility
 
 	UPROPERTY()
 	FGameplayTagContainer DynamicTags;
+
+	UPROPERTY()
+	FInstancedStruct CustomData;
 };
 
 USTRUCT()


### PR DESCRIPTION
어빌리티별로 커스텀 영구 데이터를 저장 및 복원할 수 있는 기능을 추가하여 게임 상태 지속성 지원을 강화했음.

- `USFGameplayAbility` 클래스에 `SaveCustomPersistentData` 및 `RestoreCustomPersistentData` 메서드를 추가하여 저장 및 복원 로직 구현.
- 어빌리티 영구 데이터 여부를 확인하는 `HasCustomPersistentData` 메서드 추가.
- `SFPersistentDataType`에 `FInstancedStruct` 타입의 `CustomData` 프로퍼티를 추가하여 영구 데이터를 보관.