### PR TITLE
락온(Lock-on) 및 회피(Dodge)를 위한 중복 태그 처리 로직 제거

### DIFF
--- a/Source/SF/AbilitySystem/Abilities/Hero/USFGA_Dodge.cpp
+++ b/Source/SF/AbilitySystem/Abilities/Hero/USFGA_Dodge.cpp
@@ -16,6 +16,7 @@ USFGA_Dodge::USFGA_Dodge(FObjectInitializer const& ObjectInitializer)
 	// 예측 정책 설정
 	NetExecutionPolicy = EGameplayAbilityNetExecutionPolicy::LocalPredicted;
 	SetAssetTags(FGameplayTagContainer(SFGameplayTags::Ability_Hero_Dodge));
+	ActivationOwnedTags.AddTag(SFGameplayTags::Ability_Hero_Dodge);
 }
 
 void USFGA_Dodge::ActivateAbility(const FGameplayAbilitySpecHandle Handle, const FGameplayAbilityActorInfo* ActorInfo, const FGameplayAbilityActivationInfo ActivationInfo, const FGameplayEventData* TriggerEventData)

--- a/Source/SF/Animation/Hero/SFHeroAnimInstance.cpp
+++ b/Source/SF/Animation/Hero/SFHeroAnimInstance.cpp
@@ -100,14 +100,5 @@ void USFHeroAnimInstance::NativeThreadSafeUpdateAnimation(float DeltaSeconds)
 		bIsStunned = ASC->HasMatchingGameplayTag(SFGameplayTags::Character_State_Stunned);
 		bIsSprinting = ASC->HasMatchingGameplayTag(SFGameplayTags::Character_State_Sprint);
 		bIsLockedOn = ASC->HasMatchingGameplayTag(SFGameplayTags::Character_State_LockedOn);
-		
-		if (LockOnComponent)
-		{
-			bIsLockedOn = LockOnComponent->IsLockedOn();
-		}
-		else
-		{
-			bIsLockedOn = ASC->HasMatchingGameplayTag(SFGameplayTags::Character_State_LockedOn);
-		}
 	}
 }


### PR DESCRIPTION
---

### 설명 (Description)

이 PR은 락온 및 회피 상태에 대한 태그 처리 로직을 다듬어 일관성과 유지보수성을 향상시킵니다.

- 캐릭터 상태 태그 제거와 관련된 중복 코드를 단일 `RemoveLooseGameplayTag` 호출로 통합했습니다.
- 락온 타겟 변경 시 발생하는 불필요한 태그 업데이트를 제거하여 로직을 단순화했습니다.
- `Hero_Dodge` 태그에 대한 조건 검사를 추가하여 회피 상태와의 호환성을 강화했습니다.
- `UpdateLockOnState`에 대한 중복 호출을 제거하고 불필요한 코드를 삭제하여 유지보수성을 높였습니다.

### 체크리스트 (Checklist)

- [ ] 필요한 경우 유닛 테스트가 업데이트되었는가.
- [ ] 이번 변경 사항에 대해 문서가 업데이트되었는가.
- [ ] 코드 변경 사항이 검토 및 승인되었는가.
- [ ] 관련 이해관계자들이 이 변경 사항을 인지하고 있는가.

### 관련 이슈 (Related Issues)

_관련된 이슈 없음._